### PR TITLE
Update _67_add_binary.rs

### DIFF
--- a/leetcode/src/d0/_67_add_binary.rs
+++ b/leetcode/src/d0/_67_add_binary.rs
@@ -2,8 +2,8 @@ struct Solution;
 
 impl Solution {
     fn add_binary(a: String, b: String) -> String {
-        let aa = i32::from_str_radix(&a, 2).unwrap_or(0);
-        let bb = i32::from_str_radix(&b, 2).unwrap_or(0);
+        let aa = i128::from_str_radix(&a, 2).unwrap_or(0);
+        let bb = i128::from_str_radix(&b, 2).unwrap_or(0);
         format!("{:b}", aa + bb)
     }
 }


### PR DESCRIPTION
When I completed this recently, using i32 would fail the test:

```{rust}
#[test]
fn test() {
    assert_eq!(
        Solution::add_binary("10100000100100110110010000010101111011011001101110111111111101000000101111001110001111100001101".to_string(), 
        "110101001011101110001111100110001010100001101011101010000011011011001011101111001100000011011110011".to_string()), 
        "110111101100010011000101110110100000011101000101011001000011011000001100011110011010010011000000000".to_string());
    }
```