### PR TITLE
small improvement in edge case scenario and through freeing memory

### DIFF
--- a/leetcode/src/d0/_26_remove_duplicates_from_sorted_array.rs
+++ b/leetcode/src/d0/_26_remove_duplicates_from_sorted_array.rs
@@ -3,7 +3,7 @@ struct Solution;
 impl Solution {
     fn remove_duplicates(nums: &mut Vec<i32>) -> i32 {
         let n = nums.len();
-        if n == 0 {
+        if n <= 0 {
             return 0;
         }
         let mut last = nums[0];
@@ -15,6 +15,8 @@ impl Solution {
                 size += 1;
             }
         }
+        nums.resize(size, 0);
+        nums.shrink_to_fit();
         size as i32
     }
 }


### PR DESCRIPTION
The solution works fine and goes through all tests on leetcode, but I think an important point was missed here:

Why shouldn't we just free the memory at the end of the new array (Vec). It is garbage anyways and the resize doesn't cost anything measurable in terms of performance. This solution just increases safety due to the inability to access invalid memory.

Also:
If the array len is 1, we don't have to do anything either and can just return its size, saving some allocations and deallocations on the stack.